### PR TITLE
Feat/#8 채용 공고 전체/필터 검색 API 구현 및 수정

### DIFF
--- a/jumpit/src/main/java/org/sopt/jumpit/category/domain/Category.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/category/domain/Category.java
@@ -1,11 +1,12 @@
 package org.sopt.jumpit.category.domain;
 
-
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @Table(name = "Categories")
 public class Category {
     @Id

--- a/jumpit/src/main/java/org/sopt/jumpit/category/repository/CategoryRepository.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/category/repository/CategoryRepository.java
@@ -2,6 +2,8 @@ package org.sopt.jumpit.category.repository;
 
 import org.sopt.jumpit.category.domain.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 }

--- a/jumpit/src/main/java/org/sopt/jumpit/company/domain/Company.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/company/domain/Company.java
@@ -1,10 +1,12 @@
 package org.sopt.jumpit.company.domain;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @Table(name = "Company")
 public class Company {
     @Id

--- a/jumpit/src/main/java/org/sopt/jumpit/company/repository/CompanyRepository.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/company/repository/CompanyRepository.java
@@ -2,6 +2,8 @@ package org.sopt.jumpit.company.repository;
 
 import org.sopt.jumpit.company.domain.Company;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface CompanyRepository extends JpaRepository<Company, Long> {
 }

--- a/jumpit/src/main/java/org/sopt/jumpit/global/common/dto/SuccessResponse.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/global/common/dto/SuccessResponse.java
@@ -12,7 +12,7 @@ public record SuccessResponse<T> (
     }
 
     public static <T> SuccessResponse<T> of(SuccessMessage successMessage, T data) {
-        return new SuccessResponse(successMessage.getStatus(), successMessage.getMessage(), data);
+        return new SuccessResponse<T>(successMessage.getStatus(), successMessage.getMessage(), data);
     }
 
 }

--- a/jumpit/src/main/java/org/sopt/jumpit/global/common/dto/message/ErrorMessage.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/global/common/dto/message/ErrorMessage.java
@@ -10,7 +10,11 @@ public enum ErrorMessage {
     SEARCH_FAILED(HttpStatus.BAD_REQUEST.value(), "[ERROR] 채용 공고 검색에 실패하였습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR.value(), "[ERROR] 서버 내부 오류가 발생하였습니다."),
     COMPANY_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "[ERROR] ID에 해당하는 기업이 없습니다."),
-    SKILL_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "[ERROR] ID에 해당하는 기술스택이 없습니다.")
+    SKILL_NOT_FOUND_BY_ID_EXCEPTION(HttpStatus.NOT_FOUND.value(), "[ERROR] ID에 해당하는 기술스택이 없습니다."),
+    CATEGORIES_NOT_FOUND_BY_POSITION_EXCEPTION(HttpStatus.NOT_FOUND.value(), "[ERROR] 포지션에 해당하는 카테고리가 없습니다."),
+    POSITION_NOT_FOUND_BY_CATEGORIES_EXCEPTION(HttpStatus.NOT_FOUND.value(), "[ERROR] 카테고리에 해당하는 포지션이 없습니다."),
+    POSITION_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND.value(), "[ERROR] ID에 해당하는 포지션이 없습니다."),
+    PARSE_EXCEPTION(HttpStatus.BAD_REQUEST.value(), "[ERROR] JSON 파싱에 실패하였습니다."),
     ;
 
     private final int status;

--- a/jumpit/src/main/java/org/sopt/jumpit/position/controller/PositionController.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/position/controller/PositionController.java
@@ -3,7 +3,8 @@ package org.sopt.jumpit.position.controller;
 import lombok.RequiredArgsConstructor;
 import org.sopt.jumpit.global.common.dto.SuccessResponse;
 import org.sopt.jumpit.global.common.dto.message.SuccessMessage;
-import org.sopt.jumpit.position.dto.PartialPositionFindResponse;
+import org.sopt.jumpit.position.dto.PositionDetailResponse;
+import org.sopt.jumpit.position.dto.PositionsFindResponse;
 import org.sopt.jumpit.position.service.PositionService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -18,13 +19,31 @@ public class PositionController {
 
     private final PositionService positionService;
 
-
     @GetMapping("/positions")
-    public ResponseEntity<SuccessResponse<List<PartialPositionFindResponse>>> getAllPositions(
+    public ResponseEntity<SuccessResponse<PositionsFindResponse>> getAllPositions(
             @RequestParam String keyword
     ) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(SuccessResponse.of(SuccessMessage.SEARCH_COMPLETED_SUCCESS, positionService.findPositionsByKeyword(keyword)));
     }
+
+    @GetMapping("/positions/filter")
+    public ResponseEntity<SuccessResponse<PositionsFindResponse>> getFilteredPositions(
+            @RequestParam String keyword,
+            @RequestParam List<Long> categories
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponse.of(SuccessMessage.SEARCH_COMPLETED_SUCCESS, positionService.findFilteredPositionsByKeyword(keyword, categories)));
+    }
+
+    @GetMapping("/positions/{positionId}")
+    public ResponseEntity<SuccessResponse<PositionDetailResponse>> getPositionDetail(
+            @PathVariable Long positionId
+    ) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(SuccessResponse.of(SuccessMessage.SEARCH_COMPLETED_SUCCESS, positionService.findPositionDetail(positionId)));
+    }
+
+
 
 }

--- a/jumpit/src/main/java/org/sopt/jumpit/position/domain/Position.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/position/domain/Position.java
@@ -21,7 +21,7 @@ public class Position {
     @Column(name = "contents", columnDefinition = "json")
     private String contents;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "companyId", referencedColumnName = "id")
     private Company company;
 

--- a/jumpit/src/main/java/org/sopt/jumpit/position/dto/FullPositionFindResponse.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/position/dto/FullPositionFindResponse.java
@@ -1,4 +1,0 @@
-package org.sopt.jumpit.position.dto;
-
-public record FullPositionFindResponse() {
-}

--- a/jumpit/src/main/java/org/sopt/jumpit/position/dto/PartialPositionFindResponse.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/position/dto/PartialPositionFindResponse.java
@@ -3,19 +3,22 @@ package org.sopt.jumpit.position.dto;
 import org.sopt.jumpit.company.domain.Company;
 import org.sopt.jumpit.position.domain.Position;
 import org.sopt.jumpit.skill.domain.Skill;
+import org.sopt.jumpit.skill.dto.SkillResponse;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public record PartialPositionFindResponse(
         Long id,
         String title,
-        List<Skill> skills,
+        List<SkillResponse> skills,
         Company company
 
 ) {
     public static PartialPositionFindResponse of(final Position position,
-                                                 final List<Skill> skills,
+                                                 final List<SkillResponse> skills,
                                                  final Company company) {
+
         return new PartialPositionFindResponse(
                 position.getId(),
                 position.getTitle(),

--- a/jumpit/src/main/java/org/sopt/jumpit/position/dto/PositionsFindResponse.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/position/dto/PositionsFindResponse.java
@@ -1,0 +1,11 @@
+package org.sopt.jumpit.position.dto;
+
+import java.util.List;
+
+public record PositionsFindResponse(
+        List<PartialPositionFindResponse> position
+) {
+    public static PositionsFindResponse of(List<PartialPositionFindResponse> positionFindResponses) {
+        return new PositionsFindResponse(positionFindResponses);
+    }
+}

--- a/jumpit/src/main/java/org/sopt/jumpit/position/repository/PositionRepository.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/position/repository/PositionRepository.java
@@ -2,10 +2,12 @@ package org.sopt.jumpit.position.repository;
 
 import org.sopt.jumpit.position.domain.Position;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface PositionRepository extends JpaRepository<Position, Long> {
     Optional<List<Position>> findPositionsByTitleContaining(String keyword);
 }

--- a/jumpit/src/main/java/org/sopt/jumpit/position/service/PositionService.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/position/service/PositionService.java
@@ -23,14 +23,36 @@ public class PositionService {
 
     public List<PartialPositionFindResponse> findPositionsByKeyword(String keyword) {
         return positionRepository.findPositionsByTitleContaining(keyword.trim())
+    public PositionsFindResponse findFilteredPositionsByKeyword(String keyword, List<Long> categories) {
+        // PositionCategory에서 category 넣고 position id값 List에 저장
+        List<Long> postionInCategories = new ArrayList<>();
+        for (Long categoryNumber : categories) {
+            List<PositionCategory> pc = positionCategoryService.findPositionByCategory(categoryNumber);
+            postionInCategories.addAll(pc
+                    .stream()
+                    .map(p -> {
+                        return p.getPosition().getId();
+                    }).collect(Collectors.toList())
+            );
+        }
+        // Position에서 keyword로 검색
+        return PositionsFindResponse.of(positionRepository.findPositionsByTitleContaining(keyword.trim())
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.SEARCH_FAILED))
                 .stream()
+                // 카테고리에 맞는 포지션들만 filtering
                 .map(position -> {
-                    List<Skill> skills = skillService.findByOwnerId(position.getId());
-                    return PartialPositionFindResponse.of(position, skills, position.getCompany());
+                    if(postionInCategories.contains(position.getId())) {
+                        return PartialPositionFindResponse.of(
+                                position,
+                                SkillResponse.ofList(skillService.findByOwnerId(position.getId())),
+                                position.getCompany());
+                    }
+                    return null;
                 })
-                .collect(Collectors.toList());
+                .collect(Collectors.toList())
+        );
     }
 
+        );
 
 }

--- a/jumpit/src/main/java/org/sopt/jumpit/relationship/domain/PositionCategory.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/relationship/domain/PositionCategory.java
@@ -1,10 +1,12 @@
 package org.sopt.jumpit.relationship.domain;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import org.sopt.jumpit.category.domain.Category;
 import org.sopt.jumpit.position.domain.Position;
 
 @Entity
+@Getter
 @Table(name = "Positions_Categories")
 public class PositionCategory {
     @Id

--- a/jumpit/src/main/java/org/sopt/jumpit/relationship/domain/PositionCategory.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/relationship/domain/PositionCategory.java
@@ -13,11 +13,11 @@ public class PositionCategory {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "positionId", referencedColumnName = "id")
     private Position position;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "categoryId", referencedColumnName = "id")
     private Category category;
 }

--- a/jumpit/src/main/java/org/sopt/jumpit/relationship/repository/PositionCategoryRepository.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/relationship/repository/PositionCategoryRepository.java
@@ -2,6 +2,13 @@ package org.sopt.jumpit.relationship.repository;
 
 import org.sopt.jumpit.relationship.domain.PositionCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
+@Repository
 public interface PositionCategoryRepository extends JpaRepository<PositionCategory, Long> {
+    Optional<List<PositionCategory>> findByPositionId(Long positionId);
+    Optional<List<PositionCategory>> findByCategoryId(Long categoryId);
 }

--- a/jumpit/src/main/java/org/sopt/jumpit/relationship/service/PositionCategoryService.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/relationship/service/PositionCategoryService.java
@@ -1,0 +1,29 @@
+package org.sopt.jumpit.relationship.service;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.jumpit.global.common.dto.message.ErrorMessage;
+import org.sopt.jumpit.global.exception.NotFoundException;
+import org.sopt.jumpit.relationship.domain.PositionCategory;
+import org.sopt.jumpit.relationship.repository.PositionCategoryRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+
+public class PositionCategoryService {
+    private final PositionCategoryRepository positionCategoryRepository;
+
+    public List<PositionCategory> findCategoryByPosition(Long positionId) {
+        return positionCategoryRepository.findByPositionId(positionId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.CATEGORIES_NOT_FOUND_BY_POSITION_EXCEPTION)
+        );
+    }
+
+    public List<PositionCategory> findPositionByCategory(Long categoryId) {
+        return positionCategoryRepository.findByCategoryId(categoryId).orElseThrow(
+                () -> new NotFoundException(ErrorMessage.POSITION_NOT_FOUND_BY_CATEGORIES_EXCEPTION)
+        );
+    }
+}

--- a/jumpit/src/main/java/org/sopt/jumpit/resume/repository/ResumeRepository.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/resume/repository/ResumeRepository.java
@@ -2,6 +2,8 @@ package org.sopt.jumpit.resume.repository;
 
 import org.sopt.jumpit.resume.domain.Resume;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface ResumeRepository extends JpaRepository<Resume, Long> {
 }

--- a/jumpit/src/main/java/org/sopt/jumpit/skill/domain/Skill.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/skill/domain/Skill.java
@@ -1,11 +1,13 @@
 package org.sopt.jumpit.skill.domain;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import org.sopt.jumpit.position.domain.Position;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 @Table(name = "Skills")
 public class Skill {
     @Id

--- a/jumpit/src/main/java/org/sopt/jumpit/skill/domain/Skill.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/skill/domain/Skill.java
@@ -20,7 +20,7 @@ public class Skill {
     @Column(name = "image")
     private String image;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "positionId", referencedColumnName = "id")
     private Position position;
 

--- a/jumpit/src/main/java/org/sopt/jumpit/skill/dto/SkillResponse.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/skill/dto/SkillResponse.java
@@ -1,0 +1,18 @@
+package org.sopt.jumpit.skill.dto;
+
+import org.sopt.jumpit.skill.domain.Skill;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record SkillResponse(
+        String name,
+        String image
+) {
+
+    public static List<SkillResponse> ofList (List<Skill> skills) {
+        return skills.stream()
+                .map(skill -> new SkillResponse(skill.getName(), skill.getImage()))
+                .collect(Collectors.toList());
+    }
+}

--- a/jumpit/src/main/java/org/sopt/jumpit/skill/repository/SkillRepository.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/skill/repository/SkillRepository.java
@@ -2,10 +2,12 @@ package org.sopt.jumpit.skill.repository;
 
 import org.sopt.jumpit.skill.domain.Skill;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
 
+@Repository
 public interface SkillRepository extends JpaRepository<Skill, Long> {
     Optional<List<Skill>> findByPositionId(Long id);
 }

--- a/jumpit/src/main/java/org/sopt/jumpit/user/repository/UserRepository.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/user/repository/UserRepository.java
@@ -2,6 +2,8 @@ package org.sopt.jumpit.user.repository;
 
 import org.sopt.jumpit.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 }


### PR DESCRIPTION
## 🍀 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
### 전체 검색
- API 명세서에는 Skill이 배열 형태로 나와있는 것도 있고 객체 형태로 나와있는 것도 있어서 이미지가 포함되어야 하므로 객체형태로 하기 위해 SkillResponse 라는 dto를 만들었습니다!
```java
public record SkillResponse(
        String name,
        String image
) {

    public static List<SkillResponse> ofList (List<Skill> skills) {
        return skills.stream()
                .map(skill -> new SkillResponse(skill.getName(), skill.getImage()))
                .collect(Collectors.toList());
    }
}
```
ofList 메소드는 포지션과 매핑된 기술 스택들의 List를 받아와 SkillResponse 형태의 List로 반환합니다.

- 원래의 메소드였던 PartialPositionFindResponse에 SkillResponse를 포함시켰고, API 명세처럼 position들이 따로 배열로 나타나야 하므로 PartialPositionFindResponse를 List로 갖고있는 PositionsFindResponse를 생성했습니다.
```java
// PartialPositionFindResponse
public record PartialPositionFindResponse(
        Long id,
        String title,
        List<SkillResponse> skills,
        Company company

) {
    public static PartialPositionFindResponse of(final Position position,
                                                 final List<SkillResponse> skills,
                                                 final Company company) {

        return new PartialPositionFindResponse(
                position.getId(),
                position.getTitle(),
                skills,
                company
        );
    }

// PositionsFindResponse
public record PositionsFindResponse(
        List<PartialPositionFindResponse> position
) {
    public static PositionsFindResponse of(List<PartialPositionFindResponse> positionFindResponses) {
        return new PositionsFindResponse(positionFindResponses);
    }
}
```

### 필터 검색
#### Service Logic Flow
1. PositionCategory 테이블에서 클라이언트로부터 받아온 category number 값 (id와 number는 값이 같음)으로 positionId들을 List에 저장합니다. `postionInCategories`
2. Positon 테이블에서 클라이언트로부터 받아온 keyword로 검색하는데, stream 안에서 해당 position이 1번 과정에서 진행한 List에 포함되는지 검사합니다. ` if(postionInCategories.contains(position.getId()))`
3. 2번 작업을 PositionsFindResponse.of로 dto를 만들어 반환합니다.
```java
public PositionsFindResponse findFilteredPositionsByKeyword(String keyword, List<Long> categories) {
        // PositionCategory에서 category 넣고 position id값 List에 저장
        List<Long> postionInCategories = new ArrayList<>();
        for (Long categoryNumber : categories) {
            List<PositionCategory> pc = positionCategoryService.findPositionByCategory(categoryNumber);
            postionInCategories.addAll(pc
                    .stream()
                    .map(p -> {
                        return p.getPosition().getId();
                    }).collect(Collectors.toList())
            );
        }
        // Position에서 keyword로 검색
        return PositionsFindResponse.of(positionRepository.findPositionsByTitleContaining(keyword.trim())
                .orElseThrow(() -> new NotFoundException(ErrorMessage.SEARCH_FAILED))
                .stream()
                // 카테고리에 맞는 포지션들만 filtering
                .map(position -> {
                    if(postionInCategories.contains(position.getId())) {
                        return PartialPositionFindResponse.of(
                                position,
                                SkillResponse.ofList(skillService.findByOwnerId(position.getId())),
                                position.getCompany());
                    }
                    return null;
                })
                .collect(Collectors.toList())
        );
    }
```

#### Controller
```java
@GetMapping("/positions/filter")
    public ResponseEntity<SuccessResponse<PositionsFindResponse>> getFilteredPositions(
            @RequestParam String keyword,
            @RequestParam List<Long> categories
    ) {
        return ResponseEntity.status(HttpStatus.OK)
                .body(SuccessResponse.of(SuccessMessage.SEARCH_COMPLETED_SUCCESS, positionService.findFilteredPositionsByKeyword(keyword, categories)));
    }
```
- @RequestParam으로 keyword와 categories를 입력받습니다.
- QueryParameter이기 때문에, `categories=1&categories=2&..` 형태로 Path에 넣어줘야 합니다 :)

- 1차 구현때 말씀해주신 성능 최적화는 아직 못했습니다. 기능 중심으로 먼저 구현하기 위해 :)
- yaml 파일 절대 수정하지 마세요.. 살짝 다르게 바꿨다가 헛돌기 10000000번했어요
- rds에 더미데이터 세팅 완료, ec2 빌드 및 테스트 완료 !
- ErrorMessage 추가했습니다!
- @ManyToOne에 FetchType.LAZY 추가했습니다 :)


## 🍀 어떤 것을 중점으로 리뷰 해주길 바라시나요?
- 메소드 네이밍이 괜찮은지 ... 모르겠 ...


## 🍀 공통 작업 부분에 대한 수정 사항이 있다면 적어주세요
- 


## 🍀 PR 유형
어떤 변경 사항인가요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 파일 혹은 패키지명 수정
- [ ] 파일 혹은 패키지 삭제


## 🍀 Checklist
- [ ] 코드 컨벤션을 지켰나요?
- [ ] git 컨벤션을 지켰나요?
- [ ] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [ ] 코드리뷰를 반영했나요?


### 🍀 Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #8 