### PR TITLE
Fix [#19] 지연로딩으로 인한 Json 직렬화 이슈 해결

### DIFF
--- a/jumpit/src/main/java/org/sopt/jumpit/company/dto/CompanyResponse.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/company/dto/CompanyResponse.java
@@ -1,0 +1,13 @@
+package org.sopt.jumpit.company.dto;
+
+import org.sopt.jumpit.company.domain.Company;
+
+public record CompanyResponse(
+        Long id,
+        String name,
+        String image,
+        String description) {
+    public static CompanyResponse of(Company company) {
+        return new CompanyResponse(company.getId(), company.getName(), company.getImage(), company.getDescription());
+    }
+}

--- a/jumpit/src/main/java/org/sopt/jumpit/global/common/GlobalExceptionHandler.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/global/common/GlobalExceptionHandler.java
@@ -1,7 +1,10 @@
 package org.sopt.jumpit.global.common;
 
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.json.simple.parser.ParseException;
 import org.sopt.jumpit.global.common.dto.ErrorResponse;
+import org.sopt.jumpit.global.common.dto.message.ErrorMessage;
 import org.sopt.jumpit.global.exception.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -10,9 +13,11 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.io.IOException;
 import java.util.Objects;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(NotFoundException.class)
@@ -34,9 +39,11 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.value(), "내부 서버 오류가 발생하였습니다."));
+    protected ErrorResponse handleException(final Exception error, final HttpServletRequest request) throws IOException {
+        log.error("================================================NEW===============================================");
+        log.error(error.getMessage(), error);
+        return ErrorResponse.from(String.valueOf(ErrorMessage.INTERNAL_SERVER_ERROR));
     }
+
 }
 

--- a/jumpit/src/main/java/org/sopt/jumpit/global/common/dto/SuccessResponse.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/global/common/dto/SuccessResponse.java
@@ -12,7 +12,7 @@ public record SuccessResponse<T> (
     }
 
     public static <T> SuccessResponse<T> of(SuccessMessage successMessage, T data) {
-        return new SuccessResponse<T>(successMessage.getStatus(), successMessage.getMessage(), data);
+        return new SuccessResponse<>(successMessage.getStatus(), successMessage.getMessage(), data);
     }
 
 }

--- a/jumpit/src/main/java/org/sopt/jumpit/position/dto/PartialPositionFindResponse.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/position/dto/PartialPositionFindResponse.java
@@ -1,6 +1,7 @@
 package org.sopt.jumpit.position.dto;
 
 import org.sopt.jumpit.company.domain.Company;
+import org.sopt.jumpit.company.dto.CompanyResponse;
 import org.sopt.jumpit.position.domain.Position;
 import org.sopt.jumpit.skill.domain.Skill;
 import org.sopt.jumpit.skill.dto.SkillResponse;
@@ -12,7 +13,7 @@ public record PartialPositionFindResponse(
         Long id,
         String title,
         List<SkillResponse> skills,
-        Company company
+        CompanyResponse companyResponse
 
 ) {
     public static PartialPositionFindResponse of(final Position position,
@@ -23,7 +24,7 @@ public record PartialPositionFindResponse(
                 position.getId(),
                 position.getTitle(),
                 skills,
-                company
+                CompanyResponse.of(company)
         );
     }
 

--- a/jumpit/src/main/java/org/sopt/jumpit/position/dto/PositionContents.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/position/dto/PositionContents.java
@@ -1,7 +1,5 @@
 package org.sopt.jumpit.position.dto;
 
-import com.fasterxml.jackson.annotation.JsonRootName;
-
 public record PositionContents(
     Long id,
     String title,

--- a/jumpit/src/main/java/org/sopt/jumpit/position/dto/PositionDetailResponse.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/position/dto/PositionDetailResponse.java
@@ -2,6 +2,7 @@ package org.sopt.jumpit.position.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.sopt.jumpit.company.domain.Company;
+import org.sopt.jumpit.company.dto.CompanyResponse;
 import org.sopt.jumpit.skill.dto.SkillResponse;
 
 import java.util.List;
@@ -10,7 +11,7 @@ public record PositionDetailResponse(
         @JsonProperty("positions")
         PositionContents positionContents,
         List<SkillResponse> skills,
-        Company company
+        CompanyResponse companyResponse
 ) {
 
     public static PositionDetailResponse of(
@@ -18,6 +19,6 @@ public record PositionDetailResponse(
             List<SkillResponse> skills,
             Company company) {
 
-        return new PositionDetailResponse(positionContents, skills, company);
+        return new PositionDetailResponse(positionContents, skills, CompanyResponse.of(company));
     }
 }

--- a/jumpit/src/main/java/org/sopt/jumpit/position/service/PositionService.java
+++ b/jumpit/src/main/java/org/sopt/jumpit/position/service/PositionService.java
@@ -34,12 +34,10 @@ public class PositionService {
         return PositionsFindResponse.of(positionRepository.findPositionsByTitleContaining(keyword.trim())
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.SEARCH_FAILED))
                 .stream()
-                .map(position -> {
-                    return PartialPositionFindResponse.of(
-                            position,
-                            SkillResponse.ofList(skillService.findByOwnerId(position.getId())),
-                            position.getCompany());
-                })
+                .map(position -> PartialPositionFindResponse.of(
+                        position,
+                        SkillResponse.ofList(skillService.findByOwnerId(position.getId())),
+                        position.getCompany()))
                 .collect(Collectors.toList()));
     }
 


### PR DESCRIPTION
## 🍀 작업한 내용에 대해 설명해주세요
<!-- 설명하고 싶은 코드가 있다면 첨부해주세요 -->
갑자기 @ManyToOne에 FetchType.LAZY를 설정하니까 안생기던 오류가 생겼습니다.

`com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class org.hibernate.proxy.pojo.bytebuddy.ByteBuddyInterceptor`

이 오류였는데, serializer라는 건 직렬화라는 뜻이기 때문에 지연로딩 관련 이슈라는 것을 알게 되었습니다.
지연로딩의 경우, 직접적으로 참조되는 엔티티가 아니면 나중에 로딩하여 메모리와 속도를 개선하는 것을 말하는데,
지금 저의 코드에서는 Position이 Company 객체를 가지고 있고, dto를 생성할 때 객체 자체를 반환하기 때문에 이 Company 객체가 로딩되지 않은 상태에서 로딩할려고 하니까 오류가 생긴 것입니다.
```java
public class Position {
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "companyId", referencedColumnName = "id")
    private Company company;
}
```

이를 해결하기 위해, Company 객체를 담을 CompanyResponse를 생성했습니다.
```java
public record CompanyResponse(
        Long id,
        String name,
        String image,
        String description) {
    public static CompanyResponse of(Company company) {
        return new CompanyResponse(company.getId(), company.getName(), company.getImage(), company.getDescription());
    }
}

이러니 해결! 
``` 

## 🍀 어떤 것을 중점으로 리뷰 해주길 바라시나요?
- 알고 계셨는지 .. 나만 몰랐는지 ... 


## 🍀 공통 작업 부분에 대한 수정 사항이 있다면 적어주세요
- 


## 🍀 PR 유형
어떤 변경 사항인가요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항 (오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 파일 혹은 패키지명 수정
- [ ] 파일 혹은 패키지 삭제


## 🍀 Checklist
- [x] 코드 컨벤션을 지켰나요?
- [x] git 컨벤션을 지켰나요?
- [x] PR 날리기 전에 검토하셨나요?
<!-- 스스로 QA를 진행해봤는지 (기기 대응, 앱 터지지 않는지 등) -->
- [x] 코드리뷰를 반영했나요?


### 🍀 Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #19 